### PR TITLE
Fix/socket in main thread

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,6 +58,7 @@
     },
     "dotnet.defaultSolution": "IRIS-Viz.sln",
     "cSpell.words": [
+        "IRISMSG",
         "IRISXR"
     ],
     "[csharp]": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,5 +59,8 @@
     "dotnet.defaultSolution": "IRIS-Viz.sln",
     "cSpell.words": [
         "IRISXR"
-    ]
+    ],
+    "[csharp]": {
+        "editor.defaultFormatter": "ms-dotnettools.csharp"
+    },
 }

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -316,7 +316,6 @@ GameObject:
   - component: {fileID: 1065681068}
   - component: {fileID: 1065681067}
   - component: {fileID: 1065681066}
-  - component: {fileID: 1065681069}
   m_Layer: 0
   m_Name: IRISNode
   m_TagString: Untagged
@@ -368,18 +367,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1065681069
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1065681065}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f0b42024c9c861e099e40484364ca74e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -316,6 +316,7 @@ GameObject:
   - component: {fileID: 1065681068}
   - component: {fileID: 1065681067}
   - component: {fileID: 1065681066}
+  - component: {fileID: 1065681069}
   m_Layer: 0
   m_Name: IRISNode
   m_TagString: Untagged
@@ -367,6 +368,18 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1065681069
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1065681065}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36642105dc4a5f33daf248819d0c280a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/IRISXRNode.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/IRISXRNode.cs
@@ -39,7 +39,8 @@ namespace IRIS.Node
             // NOTE: This is not necessary use DontDestroyOnLoad
             // DontDestroyOnLoad(gameObject);
             // Force to use .NET implementation of NetMQ
-            // AsyncIO.ForceDotNet.Force();
+            // It may not be necessary on Linux, but Windows requires it
+            AsyncIO.ForceDotNet.Force();
             // Initialize local node info
             localInfo = new NodeInfo
             {
@@ -294,7 +295,8 @@ namespace IRIS.Node
                     Debug.LogError($"Error closing socket {socket.GetType().Name}: {e.Message}");
                 }
             }
-            // Clean up service callbacks
+            // Clean up service callbacks.
+            // Windows require this, otherwise it will block when quitting
             NetMQConfig.Cleanup();
             Debug.Log("IRISXRNode destroyed and resources cleaned up.");
         }

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/IRISXRNode.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/IRISXRNode.cs
@@ -83,7 +83,7 @@ namespace IRIS.Node
             // Start the sending task
 
             // serviceTask = StartServiceTask(cancellationTokenSource.Token);
-            foreach (IPAddress ipAddress in NetworkUtils.GetAllNetworkInterfaces(true, true))
+            foreach (IPAddress ipAddress in NetworkUtils.GetNetworkInterfaces(true, true))
             {
                 // Start the multicast sending task for each interface
                 multicastTasksList.Add(StartMulticastAsync(ipAddress, cancellationTokenSource.Token));
@@ -202,56 +202,6 @@ namespace IRIS.Node
                 _resSocket.SendFrame(IRISSignal.ERROR);
             }
 		}
-
-
-
-        // private async Task StartServiceTask(CancellationToken cancellationToken)
-        // {
-        //     while (!cancellationToken.IsCancellationRequested)
-        //     {
-        //         try
-        //         {
-        //             // Use timeout to allow cancellation checks
-        //             List<byte[]> messageReceived = await Task.Run(() => _resSocket.ReceiveMultipartBytes(), cancellationToken);
-        //             if (messageReceived.Count > 1)
-        //             {
-        //                 // Extract service name from first frame
-        //                 string serviceName = MsgUtils.Bytes2String(messageReceived[0]);
-        //                 if (serviceCallbacks.ContainsKey(serviceName))
-        //                 {
-        //                     // Run callback on background thread if it's CPU-intensive
-        //                     byte[][] response = serviceCallbacks[serviceName](messageReceived.Skip(1).ToArray());
-        //                     _resSocket.SendMultipartBytes(response);
-        //                 }
-        //                 else
-        //                 {
-        //                     Debug.LogWarning($"Service {serviceName} not found");
-        //                     _resSocket.SendFrame(IRISSignal.NOSERVICE);
-        //                 }
-        //             }
-        //             else
-        //             {
-        //                 Debug.LogWarning("Received message does not contain service name or request data");
-        //                 _resSocket.SendFrame(IRISSignal.ERROR);
-        //             }
-        //         }
-        //         catch (TimeoutException)
-        //         {
-        //             // Timeout is expected - allows cancellation token to be checked
-        //             continue;
-        //         }
-        //         catch (OperationCanceledException)
-        //         {
-        //             Debug.Log("Service task was cancelled");
-        //             return; // Exit the loop if cancellation is requested
-        //         }
-        //         catch (Exception e)
-        //         {
-        //             Debug.LogError("Error receiving service request: " + e.Message);
-        //             _resSocket.SendFrame(IRISSignal.ERROR);
-        //         }
-        //     }
-        // }
 
 
         void OnDestroy()

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/LogStreamer.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/LogStreamer.cs
@@ -6,15 +6,15 @@ namespace IRIS.Node
     public class LogStreamer : MonoBehaviour
     {
 
-		protected string _topic;
-		protected Publisher<string> _publisher;
+        protected string _topic;
+        protected Publisher<string> _publisher;
 
-		void Start()
-		{
-			_publisher = new Publisher<string>("Log");
+        void Start()
+        {
+            _publisher = new Publisher<string>("Log");
             Application.logMessageReceived += HandleLog;
             timer = Time.realtimeSinceStartup;
-		}
+        }
 
         private int frameCounter = 0;
         private float timer = 0;
@@ -24,7 +24,8 @@ namespace IRIS.Node
             _publisher.Publish(logString);
         }
 
-        private void OnApplicationQuit() {
+        private void OnApplicationQuit()
+        {
             Application.logMessageReceived -= HandleLog;
         }
 

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/LogStreamer.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/LogStreamer.cs
@@ -1,27 +1,32 @@
 using UnityEngine;
+using IRIS.Utilities;
 
 namespace IRIS.Node
 {
 
     public class LogStreamer : MonoBehaviour
     {
-
-        protected string _topic;
-        protected Publisher<string> _publisher;
+        private Publisher<string> _logPublisher;
+        private IRISService<string, string> toggleConsoleLoggerService;
+        // private Publisher<string> _fpsPublisher;
+        // private IRISService<string, string> toggleFPSLoggerService;
+        private bool isLogStreamerEnabled = true;
 
         void Start()
         {
-            _publisher = new Publisher<string>("Log");
+            _logPublisher = new Publisher<string>("ConsoleLogger");
             Application.logMessageReceived += HandleLog;
-            timer = Time.realtimeSinceStartup;
+            toggleConsoleLoggerService = new IRISService<string, string>("ToggleConsoleLogger", ToggleLogStreamerService);
+            // _fpsPublisher = new Publisher<string>("FPS");
+            // timer = Time.realtimeSinceStartup;
         }
 
-        private int frameCounter = 0;
-        private float timer = 0;
+        // private int frameCounter = 0;
+        // private float timer = 0;
 
         void HandleLog(string logString, string stackTrace, LogType type)
         {
-            _publisher.Publish(logString);
+            _logPublisher.Publish(logString);
         }
 
         private void OnApplicationQuit()
@@ -29,18 +34,40 @@ namespace IRIS.Node
             Application.logMessageReceived -= HandleLog;
         }
 
+        public string ToggleLogStreamerService(string req)
+        {
+            if (isLogStreamerEnabled)
+            {
+                Application.logMessageReceived -= HandleLog;
+            }
+            else
+            {
+                Application.logMessageReceived += HandleLog;
+            }
+            return isLogStreamerEnabled ? IRISMSG.STOP : IRISMSG.START;
+        }
+
+
         void Update()
         {
-            frameCounter += 1;
-            float totalTime = Time.realtimeSinceStartup - timer;
-            if (totalTime > 5.0f)
-            {
-                float fps = frameCounter / totalTime;
-                HandleLog("Average FPS in the last 5s: " + fps, null, LogType.Log);
-                timer = Time.realtimeSinceStartup;
-                frameCounter = 0;
-            }
+            // TODO: finish the fps logger
+            // frameCounter += 1;
+            // float totalTime = Time.realtimeSinceStartup - timer;
+            // if (totalTime > 5.0f)
+            // {
+            //     float fps = frameCounter / totalTime;
+            //     HandleLog("Average FPS in the last 5s: " + fps, null, LogType.Log);
+            //     timer = Time.realtimeSinceStartup;
+            //     frameCounter = 0;
+            // }
         }
+
+        void OnDestroy()
+        {
+            Application.logMessageReceived -= HandleLog;
+            toggleConsoleLoggerService?.Unregister();
+        }
+
 
     }
 }

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/LogStreamer.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/LogStreamer.cs
@@ -11,7 +11,7 @@ namespace IRIS.Node
 
 		void Start()
 		{
-			_publisher = new Publisher<string>("Log", false);
+			_publisher = new Publisher<string>("Log");
             Application.logMessageReceived += HandleLog;
             timer = Time.realtimeSinceStartup;
 		}

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/MsgUtils.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/MsgUtils.cs
@@ -13,13 +13,15 @@ namespace IRIS.Utilities
 		public static readonly byte[] NODES = new byte[] { 0x02 };
 	}
 
-	public static class IRISSignal
+	public static class IRISMSG
 	{
 		public static readonly string EMPTY = "EMPTY";
 		public static readonly string SUCCESS = "SUCCESS";
 		public static readonly string ERROR = "ERROR";
-		public static readonly string NOSERVICE = "NOSERVICE";
 		public static readonly string TIMEOUT = "TIMEOUT";
+		public static readonly string NOTFOUND = "NOTFOUND";
+		public static readonly string START = "START";
+		public static readonly string STOP = "STOP";
 	}
 
 	public static class MsgUtils

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/MsgUtils.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/MsgUtils.cs
@@ -1,4 +1,3 @@
-using UnityEngine;
 using System;
 using System.IO;
 using System.Text;

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/NetComponent.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/NetComponent.cs
@@ -218,7 +218,7 @@ namespace IRIS.Node
 			}
 			catch (Exception ex)
 			{
-				Debug.LogWarning($"Error processing request for service {Name}: {ex.Message}");
+				Debug.LogWarning($"Error processing request for service {Name}: {ex.Message}\n{ex.StackTrace}");
 				return new byte[][] { HandleErrorResponse(ex) };
 			}
 		}
@@ -261,7 +261,7 @@ namespace IRIS.Node
 			}
 			catch (Exception ex)
 			{
-				Debug.LogWarning($"Error processing request for service {Name}: {ex.Message}");
+				Debug.LogWarning($"Error processing request for service {Name}: {ex.Message}\n{ex.StackTrace}");
 				return new byte[][] { HandleErrorResponse(ex) };
 			}
 		}
@@ -305,7 +305,7 @@ namespace IRIS.Node
 			}
 			catch (Exception ex)
 			{
-				Debug.LogWarning($"Error processing request for service {Name}: {ex.Message}");
+				Debug.LogWarning($"Error processing request for service {Name}: {ex.Message}\n{ex.StackTrace}");
 				return new byte[][] { HandleErrorResponse(ex) };
 			}
 		}
@@ -353,7 +353,7 @@ namespace IRIS.Node
 			}
 			catch (Exception ex)
 			{
-				Debug.LogWarning($"Error processing request for service {Name}: {ex.Message}");
+				Debug.LogWarning($"Error processing request for service {Name}: {ex.Message}\n{ex.StackTrace}");
 				return new byte[][] { HandleErrorResponse(ex) };
 			}
 		}
@@ -403,7 +403,7 @@ namespace IRIS.Node
 			}
 			catch (Exception ex)
 			{
-				Debug.LogWarning($"Error processing request for service {Name}: {ex.Message}");
+				Debug.LogWarning($"Error processing request for service {Name}: {ex.Message}\n{ex.StackTrace}");
 				return new byte[][] { HandleErrorResponse(ex) };
 			}
 		}

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/NetComponent.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/NetComponent.cs
@@ -22,17 +22,10 @@ namespace IRIS.Node
 		protected PublisherSocket _pubSocket;
 		protected string _topic;
 
-		public Publisher(string topic, bool globalNameSpace = false)
+		public Publisher(string topic)
 		{
 			IRISXRNode _XRNode = IRISXRNode.Instance;
-			if (globalNameSpace)
-			{
-				_topic = topic;
-			}
-			else
-			{
-				_topic = $"{_XRNode.localInfo.name}/{topic}";
-			}
+			_topic = topic;
 			_pubSocket = _XRNode._pubSocket;
 			if (!_XRNode.localInfo.topicList.Contains(_topic))
 			{
@@ -90,6 +83,9 @@ namespace IRIS.Node
 			_topic = topic;
 			_receiveAction = receiveAction;
 			_subSocket = new SubscriberSocket();
+			IRISXRNode _XRNode = IRISXRNode.Instance;
+			_XRNode._sockets.Add(_subSocket);
+
 		}
 
 		public void StartSubscription(string url, string topicName = null)
@@ -202,7 +198,7 @@ namespace IRIS.Node
 		public Func<byte[], RequestType> ProcessRequestFunc;
 		public Func<ResponseType, byte[]> ProcessResponseFunc;
 
-		public IRISService(string serviceName, Func<RequestType, ResponseType> onRequest, bool globalNameSpace = false)
+		public IRISService(string serviceName, Func<RequestType, ResponseType> onRequest)
 			: base(serviceName) // Call base constructor with parameters
 		{
 			_onRequest = onRequest ?? throw new ArgumentNullException(nameof(onRequest));
@@ -237,7 +233,7 @@ namespace IRIS.Node
 		public Func<byte[], RequestType2> ProcessRequest2Func;
 		public Func<ResponseType, byte[]> ProcessResponseFunc;
 
-		public IRISService(string serviceName, Func<RequestType1, RequestType2, ResponseType> onRequest, bool globalNameSpace = false)
+		public IRISService(string serviceName, Func<RequestType1, RequestType2, ResponseType> onRequest)
 			: base(serviceName)
 		{
 			_onRequest = onRequest ?? throw new ArgumentNullException(nameof(onRequest));
@@ -280,7 +276,7 @@ namespace IRIS.Node
 		public Func<byte[], RequestType3> ProcessRequest3Func;
 		public Func<ResponseType, byte[]> ProcessResponseFunc;
 
-		public IRISService(string serviceName, Func<RequestType1, RequestType2, RequestType3, ResponseType> onRequest, bool globalNameSpace = false)
+		public IRISService(string serviceName, Func<RequestType1, RequestType2, RequestType3, ResponseType> onRequest)
 			: base(serviceName)
 		{
 			_onRequest = onRequest ?? throw new ArgumentNullException(nameof(onRequest));
@@ -325,7 +321,7 @@ namespace IRIS.Node
 		public Func<byte[], RequestType4> ProcessRequest4Func;
 		public Func<ResponseType, byte[]> ProcessResponseFunc;
 
-		public IRISService(string serviceName, Func<RequestType1, RequestType2, RequestType3, RequestType4, ResponseType> onRequest, bool globalNameSpace = false)
+		public IRISService(string serviceName, Func<RequestType1, RequestType2, RequestType3, RequestType4, ResponseType> onRequest)
 			: base(serviceName)
 		{
 			_onRequest = onRequest ?? throw new ArgumentNullException(nameof(onRequest));
@@ -373,7 +369,7 @@ namespace IRIS.Node
 		public Func<byte[], RequestType5> ProcessRequest5Func;
 		public Func<ResponseType, byte[]> ProcessResponseFunc;
 
-		public IRISService(string serviceName, Func<RequestType1, RequestType2, RequestType3, RequestType4, RequestType5, ResponseType> onRequest, bool globalNameSpace = false)
+		public IRISService(string serviceName, Func<RequestType1, RequestType2, RequestType3, RequestType4, RequestType5, ResponseType> onRequest)
 			: base(serviceName)
 		{
 			_onRequest = onRequest ?? throw new ArgumentNullException(nameof(onRequest));

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/NetworkUtils.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/NetworkUtils.cs
@@ -108,7 +108,7 @@ namespace IRIS.Utilities
 			}
 		}
 
-		public static List<IPAddress> GetAllNetworkInterfaces(bool includeLoopback = false, bool includeInactive = false)
+		public static List<IPAddress> GetNetworkInterfaces(bool includeLoopback = false, bool includeInactive = false)
 		{
 			List<IPAddress> interfaceList = new List<IPAddress>();
 
@@ -143,7 +143,8 @@ namespace IRIS.Utilities
 					{
 						// Only include IPv4 addresses and skip link-local addresses
 						if (unicastInfo.Address.AddressFamily == AddressFamily.InterNetwork &&
-							!unicastInfo.Address.ToString().StartsWith("169.254")) // Skip APIPA addresses
+							!unicastInfo.Address.ToString().StartsWith("169.254") &&
+							!unicastInfo.Address.ToString().StartsWith("127.0.0.1")) // Skip APIPA addresses
 						{
 							interfaceList.Add(unicastInfo.Address);
 						}

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/UnityMainThreadDispatcher.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/UnityMainThreadDispatcher.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace IRIS.Node
+{
+    public class UnityMainThreadDispatcher : Singleton<UnityMainThreadDispatcher>
+    {
+        private readonly Queue<Action> _actions = new Queue<Action>();
+
+        public void Enqueue(Action action)
+        {
+            lock (_actions)
+            {
+                _actions.Enqueue(action);
+            }
+        }
+
+        // Execute a function on the main thread and wait for result
+        public T EnqueueAndWait<T>(Func<T> func)
+        {
+            var tcs = new TaskCompletionSource<T>();
+            
+            Enqueue(() =>
+            {
+                try
+                {
+                    var result = func();
+                    tcs.SetResult(result);
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                }
+            });
+            
+            return tcs.Task.Result;
+        }
+
+        // Execute an action on the main thread and wait for completion
+        public void EnqueueAndWait(Action action)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            
+            Enqueue(() =>
+            {
+                try
+                {
+                    action();
+                    tcs.SetResult(true);
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                }
+            });
+            
+            tcs.Task.Wait();
+        }
+
+
+
+        // Overloaded version with timeout support
+        public T EnqueueAndWait<T>(Func<T> func, int timeoutMs)
+        {
+            var tcs = new TaskCompletionSource<T>();
+            
+            Enqueue(() =>
+            {
+                try
+                {
+                    var result = func();
+                    tcs.SetResult(result);
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                }
+            });
+            
+            if (tcs.Task.Wait(timeoutMs))
+            {
+                return tcs.Task.Result;
+            }
+            else
+            {
+                throw new TimeoutException($"Operation timed out after {timeoutMs}ms");
+            }
+        }
+
+        void Update()
+        {
+            lock (_actions)
+            {
+                while (_actions.Count > 0)
+                {
+                    _actions.Dequeue().Invoke();
+                }
+            }
+        }
+    }
+}

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/UnityMainThreadDispatcher.cs.meta
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/UnityMainThreadDispatcher.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 36642105dc4a5f33daf248819d0c280a

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/QRSceneAlignment.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/QRSceneAlignment.cs
@@ -61,7 +61,7 @@ public class QRSceneAlignment : MonoBehaviour
         indicator.SetActive(true);
         Debug.Log("Start QR Tracking");
         StartQRTracking(_data);
-        return IRISSignal.SUCCESS;
+        return IRISMSG.SUCCESS;
     }
 
     public string StopQRAlignment(string signal)
@@ -70,7 +70,7 @@ public class QRSceneAlignment : MonoBehaviour
         indicator.SetActive(false);
         Debug.Log("Stop QR Tracking");
         StopQRTracking();
-        return IRISSignal.SUCCESS;
+        return IRISMSG.SUCCESS;
     }
 
     public virtual void StartQRTracking(QRSceneAlignmentData data)

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/QRSceneAlignment.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/QRSceneAlignment.cs
@@ -4,23 +4,29 @@ using UnityEngine;
 using IRIS.Node;
 using IRIS.Utilities;
 
-public class QRSceneAlignment : MonoBehaviour {
+public class QRSceneAlignment : MonoBehaviour
+{
 
     // [Serializable]
-    public class QRSceneAlignmentData {
+    public class QRSceneAlignmentData
+    {
         public string qrText;
         public List<float> pos;
         public List<float> euler;
         public bool fixZAxis;
-        public Vector3 GetPos() {
+        public Vector3 GetPos()
+        {
             return new Vector3(-pos[1], pos[2], pos[0]);
         }
 
-        public Quaternion GetRot() {
-            if (fixZAxis) {
+        public Quaternion GetRot()
+        {
+            if (fixZAxis)
+            {
                 return Quaternion.Euler(0, euler[2], 0);
             }
-            else {
+            else
+            {
                 return Quaternion.Euler(euler[1], -euler[2], -euler[0]);
             }
         }
@@ -32,20 +38,24 @@ public class QRSceneAlignment : MonoBehaviour {
     private IRISService<QRSceneAlignmentData, string> startAlignmentService;
     private IRISService<string, string> stopAlignmentService;
 
-    private void Start() {
+    private void Start()
+    {
         startAlignmentService = new("StartQRAlignment", StartQRAlignment);
         stopAlignmentService = new("StopQRAlignment", StopQRAlignment);
     }
 
-    protected void ApplyOffset() {
-        foreach (Transform child in transform) {
-            if (child.gameObject == indicator) 
+    protected void ApplyOffset()
+    {
+        foreach (Transform child in transform)
+        {
+            if (child.gameObject == indicator)
                 continue;
             child.SetLocalPositionAndRotation(_data.GetPos(), _data.GetRot());
         }
     }
 
-    public string StartQRAlignment(QRSceneAlignmentData data) {
+    public string StartQRAlignment(QRSceneAlignmentData data)
+    {
         _data = data;
         isTrackingQR = true;
         indicator.SetActive(true);
@@ -54,7 +64,8 @@ public class QRSceneAlignment : MonoBehaviour {
         return IRISSignal.SUCCESS;
     }
 
-    public string StopQRAlignment(string signal) {
+    public string StopQRAlignment(string signal)
+    {
         isTrackingQR = false;
         indicator.SetActive(false);
         Debug.Log("Stop QR Tracking");
@@ -62,14 +73,17 @@ public class QRSceneAlignment : MonoBehaviour {
         return IRISSignal.SUCCESS;
     }
 
-    public virtual void StartQRTracking(QRSceneAlignmentData data) {
+    public virtual void StartQRTracking(QRSceneAlignmentData data)
+    {
         ApplyOffset();  // Only for testing
     }
 
-    public virtual void StopQRTracking() {
+    public virtual void StopQRTracking()
+    {
     }
 
-    protected void SetSceneOrigin(Pose origin){
+    protected void SetSceneOrigin(Pose origin)
+    {
         transform.position = origin.position;
         transform.rotation = origin.rotation;
         ApplyOffset();

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/RigidObjectsController.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/RigidObjectsController.cs
@@ -7,7 +7,7 @@ namespace IRIS.SceneLoader
 {
 
     [Serializable]
-    public class StreamMessage : Dictionary<string, List<float>> {}
+    public class StreamMessage : Dictionary<string, List<float>> { }
 
     [RequireComponent(typeof(SimSceneLoader))]
     public class RigidObjectsController : MonoBehaviour

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/SimData.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/SimData.cs
@@ -45,6 +45,8 @@ namespace IRIS.SceneLoader
 	public class SimObject : SimAsset
 	{
 		public IRISTransform trans;
+		public List<SimVisual> visuals;
+		public List<SimObject> children;
 	}
 
 	public class SimScene : SimAsset

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/SimData.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/SimData.cs
@@ -52,9 +52,9 @@ namespace IRIS.SceneLoader
 		// public SimObject root;
 	}
 
-	
 
-	
+
+
 	public class SimMesh : SimAsset
 	{
 		public string hash;
@@ -65,7 +65,7 @@ namespace IRIS.SceneLoader
 
 	}
 
-	
+
 	public class SimMaterial : SimAsset
 	{
 		public string hash;
@@ -77,7 +77,7 @@ namespace IRIS.SceneLoader
 		public SimTexture texture;
 	}
 
-	
+
 	public class SimTexture : SimAsset
 	{
 		public string hash;

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/SimSceneLoader.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/SimSceneLoader.cs
@@ -73,6 +73,23 @@ namespace IRIS.SceneLoader
             }
             RegisterGameObject(simObject, newSimGameObject);
             ApplyTransform(newSimGameObject.transform, simObject.trans);
+            if (simObject.visuals != null)
+            {
+                foreach (var visual in simObject.visuals)
+                {
+                    // Skip creating visuals with mesh or material
+                    if (visual.mesh != null) continue;
+                    if (visual.material != null && visual.material.texture != null) continue;
+                    CreateSimVisual(newSimGameObject.name, visual, null, null);
+                }
+            }
+            if (simObject.children != null)
+            {
+                foreach (var child in simObject.children)
+                {
+                    CreateSimObject(newSimGameObject.name, child);
+                }
+            }
             Debug.Log($"Created SimObject: {simObject.name}");
         }
 

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/SimSceneLoader.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/SimSceneLoader.cs
@@ -14,15 +14,19 @@ namespace IRIS.SceneLoader
         [SerializeField] private GameObject sceneAxis;
         private Dictionary<string, GameObject> _simObjectDict = new();
         private Dictionary<string, Transform> _simObjTransDict = new();
-        private List<INetComponent> _serviceList = new();
+        // SceneLoader services
+        private IRISService<string, SimObject, string> createSimObjectService;
+        private IRISService<string, SimVisual, byte[], byte[], string> createSimVisualService;
+        private IRISService<string, string> subscribeRigidObjectsControllerService;
 
         void Start()
         {
             sceneAxis.SetActive(false);
             sceneAxis.name = $"{name}_SceneAxis_IRIS";
-            _serviceList.Add(new IRISService<string, SimObject, string>($"{gameObject.name}/CreateSimObject", CreateSimObjectCb));
-            _serviceList.Add(new IRISService<string, SimVisual, byte[], byte[], string>($"{gameObject.name}/CreateVisual", CreateSimVisualCb));
-            _serviceList.Add(new IRISService<string, string>($"{gameObject.name}/SubscribeRigidObjectsController", SubscribeRigidObjectsControllerCb));
+            IRISXRNode _xrNode = IRISXRNode.Instance;
+            createSimObjectService = new IRISService<string, SimObject, string>($"{gameObject.name}/CreateSimObject", CreateSimObjectCb);
+            createSimVisualService = new IRISService<string, SimVisual, byte[], byte[], string>($"{gameObject.name}/CreateVisual", CreateSimVisualCb);
+            subscribeRigidObjectsControllerService = new IRISService<string, string>($"{gameObject.name}/SubscribeRigidObjectsController", SubscribeRigidObjectsControllerCb);
         }
 
         static void ApplyTransform(Transform uTransform, IRISTransform simTrans)
@@ -51,7 +55,7 @@ namespace IRIS.SceneLoader
         private string CreateSimObjectCb(string parentName, SimObject simObject)
         {
             CreateSimObject(parentName, simObject);
-            return IRISSignal.SUCCESS;
+            return IRISMSG.SUCCESS;
         }
 
         public void CreateSimObject(string parentName, SimObject simObject)
@@ -96,7 +100,7 @@ namespace IRIS.SceneLoader
         private string CreateSimVisualCb(string objName, SimVisual simVisual, byte[] meshBytes, byte[] textureBytes)
         {
             CreateSimVisual(objName, simVisual, meshBytes, textureBytes);
-            return IRISSignal.SUCCESS;
+            return IRISMSG.SUCCESS;
         }
 
 
@@ -209,7 +213,7 @@ namespace IRIS.SceneLoader
 
             RigidObjectsController rigidObjectsController = GetComponent<RigidObjectsController>();
             rigidObjectsController.StartSubscription(url);
-            return IRISSignal.SUCCESS;
+            return IRISMSG.SUCCESS;
         }
 
 
@@ -225,11 +229,9 @@ namespace IRIS.SceneLoader
 
         private void OnDestroy()
         {
-            foreach (var service in _serviceList)
-            {
-                service.Unregister();
-            }
-            _serviceList.Clear();
+            createSimObjectService?.Unregister();
+            createSimVisualService?.Unregister();
+            subscribeRigidObjectsControllerService?.Unregister();
             _simObjectDict.Clear();
             _simObjTransDict.Clear();
         }

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/SimSceneLoader.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/SimSceneLoader.cs
@@ -206,7 +206,8 @@ namespace IRIS.SceneLoader
             return _simObjTransDict;
         }
 
-        private void OnDestroy() {
+        private void OnDestroy()
+        {
             foreach (var service in _serviceList)
             {
                 service.Unregister();

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/SimSceneSpawner.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/SimSceneSpawner.cs
@@ -27,12 +27,12 @@ namespace IRIS.SceneLoader
             if (_simSceneDict.ContainsKey(simScene.name))
             {
                 Debug.LogWarning($"SimScene with id {simScene.name} already exists, reusing the existing scene.");
-                return IRISSignal.SUCCESS;
+                return IRISMSG.SUCCESS;
             }
             GameObject simSceneObj = Instantiate(simScenePrefab, gameObject.transform);
             simSceneObj.name = simScene.name;
             _simSceneDict.Add(simScene.name, simSceneObj);
-            return IRISSignal.SUCCESS;
+            return IRISMSG.SUCCESS;
         }
 
         private string DeleteSimScene(string simSceneId)
@@ -41,12 +41,12 @@ namespace IRIS.SceneLoader
             {
                 Destroy(_simSceneDict[simSceneId]);
                 _simSceneDict.Remove(simSceneId);
-                return IRISSignal.SUCCESS;
+                return IRISMSG.SUCCESS;
             }
             else
             {
                 Debug.LogWarning($"SimScene with id {simSceneId} does not exist.");
-                return IRISSignal.ERROR;
+                return IRISMSG.ERROR;
             }
         }
 

--- a/Packages/com.intuitiverobotslab.iris-viz/package.json
+++ b/Packages/com.intuitiverobotslab.iris-viz/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.intuitiverobotslab.iris-viz",
-    "version": "1.1.0",
+    "version": "1.1.2",
     "displayName": "IRIS-Viz",
     "description": "A Unity package for visualizing objects in simulation and real world",
     "unity": "6000.0",

--- a/Packages/com.intuitiverobotslab.iris-viz/package.json
+++ b/Packages/com.intuitiverobotslab.iris-viz/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.intuitiverobotslab.iris-viz",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "displayName": "IRIS-Viz",
     "description": "A Unity package for visualizing objects in simulation and real world",
     "unity": "6000.0",


### PR DESCRIPTION
This pull request introduces significant changes to the `IRISXRNode` and related components to improve service handling, logging, and resource management. Key updates include refactoring service initialization, enhancing error handling, and simplifying the `Publisher` and `IRISService` classes. Additionally, new utilities and services have been added to streamline functionality.

### Refactoring and Service Improvements:
* Refactored `IRISXRNode` to initialize services (`getNodeInfoService`, `renameService`, `getServiceListService`) as distinct objects instead of using a dictionary for service management. This improves clarity and type safety. (`[[1]](diffhunk://#diff-de1ca0bb25e184bfda033036efa43e8b1af533c63a3932404c4258a3acf98561L21-L45)`, `[[2]](diffhunk://#diff-de1ca0bb25e184bfda033036efa43e8b1af533c63a3932404c4258a3acf98561L107-R107)`)
* Added `ServiceRespondSpin` method for non-blocking service request handling, ensuring responsiveness in the main thread. (`[Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/IRISXRNode.csL153-R237](diffhunk://#diff-de1ca0bb25e184bfda033036efa43e8b1af533c63a3932404c4258a3acf98561L153-R237)`)
* Enhanced error handling in service and multicast tasks with more detailed exception logging, including stack traces. (`[[1]](diffhunk://#diff-de1ca0bb25e184bfda033036efa43e8b1af533c63a3932404c4258a3acf98561L139-R134)`, `[[2]](diffhunk://#diff-de1ca0bb25e184bfda033036efa43e8b1af533c63a3932404c4258a3acf98561L199-R266)`)

### Logging Enhancements:
* Introduced `LogStreamer` improvements, including a `ToggleLogStreamerService` to enable or disable logging dynamically. This allows better runtime control of logging behavior. (`[Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/LogStreamer.csR2-R71](diffhunk://#diff-c9100ac75493beaee4b61b196e67d27532e52037d4d7b4e4ea5f1ba3b3009f4eR2-R71)`)
* Updated logging to use a dedicated `Publisher` instance (`_logPublisher`) for console logs. (`[Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/LogStreamer.csR2-R71](diffhunk://#diff-c9100ac75493beaee4b61b196e67d27532e52037d4d7b4e4ea5f1ba3b3009f4eR2-R71)`)

### Code Simplification:
* Removed the `globalNameSpace` parameter from the `Publisher` and `IRISService` constructors, simplifying their usage. (`[[1]](diffhunk://#diff-0641577e01b3c6fe6050d337d82e9f594b75982ad2c956f2f515c1dece77bcf6L25-L35)`, `[[2]](diffhunk://#diff-0641577e01b3c6fe6050d337d82e9f594b75982ad2c956f2f515c1dece77bcf6L205-R201)`)
* Simplified topic handling in the `Publisher` class by removing namespace prefixes. (`[Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/NetComponent.csL25-L35](diffhunk://#diff-0641577e01b3c6fe6050d337d82e9f594b75982ad2c956f2f515c1dece77bcf6L25-L35)`)

### Resource Cleanup:
* Improved resource cleanup in `OnDestroy` methods for both `IRISXRNode` and `LogStreamer`, including unregistering services and cleaning up sockets and callbacks. (`[[1]](diffhunk://#diff-de1ca0bb25e184bfda033036efa43e8b1af533c63a3932404c4258a3acf98561L225-L235)`, `[[2]](diffhunk://#diff-c9100ac75493beaee4b61b196e67d27532e52037d4d7b4e4ea5f1ba3b3009f4eR2-R71)`)
* Added a call to `NetMQConfig.Cleanup` during destruction to prevent potential blocking issues on Windows. (`[Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/IRISXRNode.csR303-R316](diffhunk://#diff-de1ca0bb25e184bfda033036efa43e8b1af533c63a3932404c4258a3acf98561R303-R316)`)

### Miscellaneous Updates:
* Replaced `IRISSignal` with `IRISMSG` for standardized message constants, adding new states like `START`, `STOP`, and `NOTFOUND`. (`[Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/MsgUtils.csL17-R24](diffhunk://#diff-0df33441c8b77b890f9be234e4a50370758828a3da9942a8607baaa6117c427eL17-R24)`)
* Updated method names for clarity, such as renaming `StartMulticastTask` to `StartMulticastAsync`. (`[Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/IRISXRNode.csL107-R107](diffhunk://#diff-de1ca0bb25e184bfda033036efa43e8b1af533c63a3932404c4258a3acf98561L107-R107)`)