### PR TITLE
change StartServiceTask to async make sub-thread running on Windows Editor

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -317,6 +317,7 @@ GameObject:
   - component: {fileID: 1065681067}
   - component: {fileID: 1065681066}
   - component: {fileID: 1065681069}
+  - component: {fileID: 1065681070}
   m_Layer: 0
   m_Name: IRISNode
   m_TagString: Untagged
@@ -352,7 +353,6 @@ MonoBehaviour:
   multicastAddress: 239.255.10.10
   port: 7720
   messageSendInterval: 1
-  serviceList: []
 --- !u!4 &1065681068
 Transform:
   m_ObjectHideFlags: 0
@@ -378,6 +378,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 36642105dc4a5f33daf248819d0c280a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1065681070
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1065681065}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db9e6eb7bb0e36f5a8cefd1aa9e2655d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1660057539 &9223372036854775807

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -305,97 +305,67 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1065681065
-GameObject:
+--- !u!1001 &5868478775607048197
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1065681068}
-  - component: {fileID: 1065681067}
-  - component: {fileID: 1065681066}
-  - component: {fileID: 1065681069}
-  - component: {fileID: 1065681070}
-  m_Layer: 0
-  m_Name: IRISNode
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1065681066
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1065681065}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b181f1d35a19aae19ac9cd78e5c69be2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  simScenePrefab: {fileID: 3537466871457611858, guid: 126bffd15ec827eb9a4e421fcb306cc1, type: 3}
---- !u!114 &1065681067
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1065681065}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e4c8106baaae0d489138369a4fb1533, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  multicastAddress: 239.255.10.10
-  port: 7720
-  messageSendInterval: 1
---- !u!4 &1065681068
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1065681065}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1065681069
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1065681065}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 36642105dc4a5f33daf248819d0c280a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1065681070
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1065681065}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db9e6eb7bb0e36f5a8cefd1aa9e2655d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5416606952447211905, guid: de2495710546adb4bb1d60e91b7db0d1, type: 3}
+      propertyPath: m_Name
+      value: IRISNode
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150505001985269035, guid: de2495710546adb4bb1d60e91b7db0d1, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150505001985269035, guid: de2495710546adb4bb1d60e91b7db0d1, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150505001985269035, guid: de2495710546adb4bb1d60e91b7db0d1, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150505001985269035, guid: de2495710546adb4bb1d60e91b7db0d1, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150505001985269035, guid: de2495710546adb4bb1d60e91b7db0d1, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150505001985269035, guid: de2495710546adb4bb1d60e91b7db0d1, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150505001985269035, guid: de2495710546adb4bb1d60e91b7db0d1, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150505001985269035, guid: de2495710546adb4bb1d60e91b7db0d1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150505001985269035, guid: de2495710546adb4bb1d60e91b7db0d1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150505001985269035, guid: de2495710546adb4bb1d60e91b7db0d1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: de2495710546adb4bb1d60e91b7db0d1, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 330585546}
   - {fileID: 832575519}
-  - {fileID: 1065681068}
+  - {fileID: 5868478775607048197}

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Prefabs.meta
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 062ec7a37b30c5e4bb7542dc57b5f7f1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Prefabs/IRISNode.prefab
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Prefabs/IRISNode.prefab
@@ -1,0 +1,89 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5416606952447211905
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8150505001985269035}
+  - component: {fileID: 2407004314157632247}
+  - component: {fileID: 3203194774513815821}
+  - component: {fileID: 259209534123663940}
+  - component: {fileID: 2875731928885332986}
+  m_Layer: 0
+  m_Name: IRISNode
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8150505001985269035
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5416606952447211905}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2407004314157632247
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5416606952447211905}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e4c8106baaae0d489138369a4fb1533, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  multicastAddress: 239.255.10.10
+  port: 7720
+  messageSendInterval: 1
+--- !u!114 &3203194774513815821
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5416606952447211905}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b181f1d35a19aae19ac9cd78e5c69be2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  simScenePrefab: {fileID: 3537466871457611858, guid: 126bffd15ec827eb9a4e421fcb306cc1, type: 3}
+--- !u!114 &259209534123663940
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5416606952447211905}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36642105dc4a5f33daf248819d0c280a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2875731928885332986
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5416606952447211905}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db9e6eb7bb0e36f5a8cefd1aa9e2655d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Prefabs/IRISNode.prefab.meta
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Prefabs/IRISNode.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: de2495710546adb4bb1d60e91b7db0d1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/IRISXRNode.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/IRISXRNode.cs
@@ -77,7 +77,7 @@ namespace IRIS.Node
 
             // Initialize cancellation token
             cancellationTokenSource = new CancellationTokenSource();
-            serviceTask = Task.Run(() => StartServiceTask(cancellationTokenSource.Token), cancellationTokenSource.Token);
+            serviceTask = Task.Run(async () => await StartServiceTask(cancellationTokenSource.Token), cancellationTokenSource.Token);
             foreach (IPAddress ipAddress in NetworkUtils.GetNetworkInterfaces(true, true))
             {
                 // Start the multicast sending task for each interface
@@ -197,11 +197,12 @@ namespace IRIS.Node
             }
         }
 
-        private void StartServiceTask(CancellationToken cancellationToken)
+        private async Task StartServiceTask(CancellationToken cancellationToken)
         {
             while (!cancellationToken.IsCancellationRequested)
             {
                 if (!_resSocket.HasIn) continue;
+                await Task.Delay(50, cancellationToken);
                 try
                 {
                     // Use timeout to allow cancellation checks
@@ -281,7 +282,8 @@ namespace IRIS.Node
             // Wait for service task completion
             try
             {
-                serviceTask?.Wait(TimeSpan.FromSeconds(0.5));
+                serviceTask?.Wait();
+                Debug.Log("Service task completed successfully.");
             }
             catch (Exception e)
             {

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/LogStreamer.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/LogStreamer.cs
@@ -19,10 +19,11 @@ namespace IRIS.Node
             toggleConsoleLoggerService = new IRISService<string, string>("ToggleConsoleLogger", ToggleLogStreamerService);
             // _fpsPublisher = new Publisher<string>("FPS");
             // timer = Time.realtimeSinceStartup;
+            InvokeRepeating("PublishTestLog", 0.0f, 1.0f);
         }
 
-        // private int frameCounter = 0;
-        // private float timer = 0;
+        private int frameCounter = 0;
+        private float timer = 0;
 
         void HandleLog(string logString, string stackTrace, LogType type)
         {
@@ -47,14 +48,20 @@ namespace IRIS.Node
             return isLogStreamerEnabled ? IRISMSG.STOP : IRISMSG.START;
         }
 
+        void PublishTestLog()
+        {
+            Debug.Log("Total time: " + frameCounter);
+            frameCounter += 1;
+        }
 
         void Update()
         {
-            // _logPublisher.Publish("LogStreamer is running...");
-            Debug.Log("LogStreamer is running...");
-            // TODO: finish the fps logger
+            // Debug.Log("Total time: " + frameCounter);
+            // // Debug.Log("LogStreamer is running...");
+            // // TODO: finish the fps logger
             // frameCounter += 1;
             // float totalTime = Time.realtimeSinceStartup - timer;
+            // _logPublisher.Publish("Total time: " + totalTime + " seconds, Frame count: " + frameCounter);
             // if (totalTime > 5.0f)
             // {
             //     float fps = frameCounter / totalTime;

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/LogStreamer.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/LogStreamer.cs
@@ -19,7 +19,7 @@ namespace IRIS.Node
             toggleConsoleLoggerService = new IRISService<string, string>("ToggleConsoleLogger", ToggleLogStreamerService);
             // _fpsPublisher = new Publisher<string>("FPS");
             // timer = Time.realtimeSinceStartup;
-            InvokeRepeating("PublishTestLog", 0.0f, 1.0f);
+            // InvokeRepeating("PublishTestLog", 0.0f, 1.0f);
         }
 
         private int frameCounter = 0;

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/LogStreamer.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/LogStreamer.cs
@@ -50,6 +50,8 @@ namespace IRIS.Node
 
         void Update()
         {
+            // _logPublisher.Publish("LogStreamer is running...");
+            Debug.Log("LogStreamer is running...");
             // TODO: finish the fps logger
             // frameCounter += 1;
             // float totalTime = Time.realtimeSinceStartup - timer;

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/NetworkUtils.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/IRISNode/Scripts/NetworkUtils.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Net.NetworkInformation;
 using UnityEngine;
+using NetMQ;
 
 namespace IRIS.Utilities
 {
@@ -32,10 +33,9 @@ namespace IRIS.Utilities
 		public string name;
 		public string nodeID;
 		public string type;
-		public int servicePort;
-		public int topicPort;
+		public int port;
 		public List<string> serviceList = new();
-		public List<string> topicList = new();
+		public Dictionary<string, int> topicDict = new();
 	}
 
 	public static class NetworkUtils
@@ -174,6 +174,14 @@ namespace IRIS.Utilities
 				}
 			}
 			return true;
+		}
+
+		public static int GetNetZMQSocketPort(NetMQSocket _socket)
+		{
+			string pubEndpoint = _socket.Options.LastEndpoint;
+			Debug.Log($"Publisher initialized at port {pubEndpoint}");
+			string pubPortString = pubEndpoint.Split(':')[2];
+			return pubPortString != null ? int.Parse(pubPortString) : 0;
 		}
 
 	}

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/SimSceneLoader.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/SimSceneLoader.cs
@@ -112,6 +112,7 @@ namespace IRIS.SceneLoader
                 return;
             }
             GameObject visualObj;
+            Debug.Log($"Creating visual for {objName}");
             switch (simVisual.type)
             {
                 case "CUBE":

--- a/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/SimSceneLoader.cs
+++ b/Packages/com.intuitiverobotslab.iris-viz/Runtime/SceneLoader/Scripts/SimSceneLoader.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Runtime.InteropServices;
 using IRIS.Node;
 using IRIS.Utilities;
+using Unity.Android.Gradle.Manifest;
 
 namespace IRIS.SceneLoader
 {
@@ -54,7 +55,10 @@ namespace IRIS.SceneLoader
 
         private string CreateSimObjectCb(string parentName, SimObject simObject)
         {
-            CreateSimObject(parentName, simObject);
+            UnityMainThreadDispatcher.Instance.Enqueue(() =>
+            {
+                CreateSimObject(parentName, simObject);
+            });
             return IRISMSG.SUCCESS;
         }
 
@@ -99,7 +103,10 @@ namespace IRIS.SceneLoader
 
         private string CreateSimVisualCb(string objName, SimVisual simVisual, byte[] meshBytes, byte[] textureBytes)
         {
-            CreateSimVisual(objName, simVisual, meshBytes, textureBytes);
+            UnityMainThreadDispatcher.Instance.Enqueue(() =>
+            {
+                CreateSimVisual(objName, simVisual, meshBytes, textureBytes);
+            });
             return IRISMSG.SUCCESS;
         }
 
@@ -211,9 +218,11 @@ namespace IRIS.SceneLoader
 
         private string SubscribeRigidObjectsControllerCb(string url)
         {
-
-            RigidObjectsController rigidObjectsController = GetComponent<RigidObjectsController>();
-            rigidObjectsController.StartSubscription(url);
+            UnityMainThreadDispatcher.Instance.Enqueue(() =>
+            {
+                RigidObjectsController rigidObjectsController = GetComponent<RigidObjectsController>();
+                rigidObjectsController.StartSubscription(url);
+            });
             return IRISMSG.SUCCESS;
         }
 


### PR DESCRIPTION
This pull request refactors the `IRISXRNode` class to improve the handling of asynchronous tasks and ensure proper task completion. The most important changes include making the `StartServiceTask` method asynchronous, adding a delay to the task loop for better responsiveness, and improving task cleanup in the `OnDestroy` method.

### Asynchronous Task Handling:

* [`IRISXRNode.cs`](diffhunk://#diff-de1ca0bb25e184bfda033036efa43e8b1af533c63a3932404c4258a3acf98561L200-R205): Updated `StartServiceTask` to be an `async Task` method, allowing for asynchronous execution. This change ensures better scalability and responsiveness.
* [`IRISXRNode.cs`](diffhunk://#diff-de1ca0bb25e184bfda033036efa43e8b1af533c63a3932404c4258a3acf98561L80-R80): Modified the `serviceTask` initialization in `Start()` to use `async`/`await`, aligning with the updated `StartServiceTask` method.

### Responsiveness Improvements:

* [`IRISXRNode.cs`](diffhunk://#diff-de1ca0bb25e184bfda033036efa43e8b1af533c63a3932404c4258a3acf98561L200-R205): Added a 50ms delay (`Task.Delay`) within the `StartServiceTask` loop to reduce CPU usage and improve responsiveness during the task execution.

### Task Cleanup:

* [`IRISXRNode.cs`](diffhunk://#diff-de1ca0bb25e184bfda033036efa43e8b1af533c63a3932404c4258a3acf98561L284-R286): Improved task cleanup in `OnDestroy` by removing the timeout from `serviceTask.Wait()` and adding a debug log to confirm task completion. This ensures proper resource cleanup and provides better debugging information.